### PR TITLE
Fix: Indicate loading for all search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fix
+
+- Show loading indicator on all search results
+
 ## [1.3.1] 2023-09-29
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fix
 
 - Show loading indicator on all search results
+- Made searching indicator text value translatable
 - Ensure drupal states are run when updating form values with JavaScript.
   (<https://github.com/itk-dev/os2forms_organisation/pull/17>)
 

--- a/assets/os2forms_organisation.js
+++ b/assets/os2forms_organisation.js
@@ -41,6 +41,7 @@ window.addEventListener("load", () => {
       }
     });
   });
+
   document.querySelector("input[data-name='search-user-query']").addEventListener("click", (e) => {
       const searchButton = e.target;
       if (searchButton.classList.contains("submit-loading")) {
@@ -51,7 +52,8 @@ window.addEventListener("load", () => {
       searchButton.value = "Henter..";
     });
 
-    document.querySelector("table.os2forms-organisation-search-result-table > tbody > tr > td > button").addEventListener("click", (e) => {
+  document.querySelectorAll("table.os2forms-organisation-search-result-table > tbody > tr > td > button").forEach((el) => {
+    el.addEventListener("click", (e) => {
       const searchButton = e.target;
       if (searchButton.classList.contains("submit-loading")) {
         e.preventDefault();
@@ -60,5 +62,6 @@ window.addEventListener("load", () => {
       searchButton.classList.add("submit-loading");
       searchButton.innerHTML = "Henter..";
     });
+  });
 
 });

--- a/assets/os2forms_organisation.js
+++ b/assets/os2forms_organisation.js
@@ -53,7 +53,7 @@ window.addEventListener("load", () => {
         return false;
       }
       searchButton.classList.add("submit-loading");
-      searchButton.value = "Henter..";
+      searchButton.value = Drupal.t("Fetching");
     });
 
   document.querySelectorAll("table.os2forms-organisation-search-result-table > tbody > tr > td > button").forEach((el) => {
@@ -64,7 +64,7 @@ window.addEventListener("load", () => {
         return false;
       }
       searchButton.classList.add("submit-loading");
-      searchButton.innerHTML = "Henter..";
+      searchButton.innerHTML = Drupal.t("Fetching");
     });
   });
 

--- a/os2forms_organisation.libraries.yml
+++ b/os2forms_organisation.libraries.yml
@@ -5,3 +5,5 @@ os2forms_organisation:
       assets/os2forms_organisation.css: {}
   js:
     assets/os2forms_organisation.js: {}
+  dependencies:
+    - core/drupal


### PR DESCRIPTION
* Adds missing `forEach` to ensure indicator is shown when selecting non-first(?) search results
* Makes search indicator text translatable