### PR TITLE
1615: Removed search button value changes functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Removed search button value changes functionality.
+
 ## [2.0.1] 2024-01-23
 
 - Hid funktion selector by default.

--- a/assets/os2forms_organisation.js
+++ b/assets/os2forms_organisation.js
@@ -56,7 +56,6 @@ window.addEventListener("load", () => {
         return false;
       }
       searchButton.classList.add("submit-loading");
-      searchButton.value = Drupal.t("Fetching");
     });
   }
 

--- a/src/Commands/Commands.php
+++ b/src/Commands/Commands.php
@@ -83,9 +83,13 @@ class Commands extends DrushCommands {
    * @throws \Drupal\os2forms_organisation\Exception\ApiException
    *   API exception.
    */
-  public function read(string $type, string $uuid, array $options = [
-    'manager-levels' => 1,
-  ]): void {
+  public function read(
+    string $type,
+    string $uuid,
+    array $options = [
+      'manager-levels' => 1,
+    ],
+  ): void {
     $this->readOptions = $options;
 
     switch ($type) {


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1615

* Removed search button value changes functionality


The change in search button value resulted in wrong `triggering_element` in webforms with certain element order. See leantime for more information.